### PR TITLE
Set kdcproxyname custom RDP Property on Host Pool

### DIFF
--- a/workload/bicep/deploy-baseline-arpah.bicep
+++ b/workload/bicep/deploy-baseline-arpah.bicep
@@ -112,7 +112,7 @@ param hostPoolMaxSessions int = 8
 param avdStartVmOnConnect bool = true
 
 @sys.description('AVD host pool Custom RDP properties. (Default: audiocapturemode:i:1;audiomode:i:0;drivestoredirect:s:;redirectclipboard:i:1;redirectcomports:i:1;redirectprinters:i:1;redirectsmartcards:i:1;screen mode id:i:2)')
-param avdHostPoolRdpProperties string = 'audiocapturemode:i:1;audiomode:i:0;drivestoredirect:s:;redirectclipboard:i:1;redirectcomports:i:1;redirectprinters:i:1;redirectsmartcards:i:1;screen mode id:i:2'
+param avdHostPoolRdpProperties string = 'audiocapturemode:i:1;audiomode:i:0;drivestoredirect:s:;kdcproxyname:s:<fqdnhere>;redirectclipboard:i:1;redirectcomports:i:1;redirectprinters:i:1;redirectsmartcards:i:1;screen mode id:i:2'
 
 @sys.description('AVD deploy scaling plan. (Default: true)')
 param avdDeployScalingPlan bool = true


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Per the use of Smart Card authentication to Azure Virtual Desktop, the [Key Distribution Center (KDC) custom RDP Property](https://learn.microsoft.com/en-us/azure/virtual-desktop/key-distribution-center-proxy#how-to-configure-the-kdc-proxy) must be set on the host pool to [enable Kerberos security ticket communication with a domain controller](https://learn.microsoft.com/en-us/azure/virtual-desktop/authentication#smart-card-and-windows-hello-for-business).

## This PR adds

1. Adds kdcproxyname custom RDP Property to the host pool with the KDC Proxy FQDN.
