### PR TITLE
Storage static pep ip

### DIFF
--- a/workload/bicep/deploy-baseline-arpah.bicep
+++ b/workload/bicep/deploy-baseline-arpah.bicep
@@ -1172,6 +1172,7 @@ module msixAzureFilesStorage './modules/storageAzureFiles/deploy.bicep' = if (va
         workloadSubsId: avdWorkloadSubsId
         tags: createResourceTags ? union(varCustomResourceTags, varAvdDefaultTags) : varAvdDefaultTags
         alaWorkspaceResourceId: avdDeployMonitoring ? (deployAlaWorkspace ? monitoringDiagnosticSettings.outputs.avdAlaWorkspaceResourceId : alaExistingWorkspaceResourceId) : ''
+        storageFilePrivateEndpointStaticIp: storageFilePrivateEndpointStaticIp
     }
     dependsOn: [
         fslogixAzureFilesStorage

--- a/workload/bicep/deploy-baseline-arpah.bicep
+++ b/workload/bicep/deploy-baseline-arpah.bicep
@@ -481,6 +481,9 @@ param enableTelemetry bool = true
 @sys.description('Enable purge protection for the keyvaults. (Default: true)')
 param enableKvPurgeProtection bool = true
 
+@sys.description('Storage account private endpoint static ip')
+param storageFilePrivateEndpointStaticIp string
+
 // =========== //
 // Variable declaration //
 // =========== //
@@ -1124,6 +1127,7 @@ module fslogixAzureFilesStorage './modules/storageAzureFiles/deploy.bicep' = if 
         workloadSubsId: avdWorkloadSubsId
         tags: createResourceTags ? union(varCustomResourceTags, varAvdDefaultTags) : varAvdDefaultTags
         alaWorkspaceResourceId: avdDeployMonitoring ? (deployAlaWorkspace ? monitoringDiagnosticSettings.outputs.avdAlaWorkspaceResourceId : alaExistingWorkspaceResourceId) : ''
+        storageFilePrivateEndpointStaticIp: storageFilePrivateEndpointStaticIp
     }
     dependsOn: [
         baselineStorageResourceGroup

--- a/workload/bicep/modules/storageAzureFiles/deploy.bicep
+++ b/workload/bicep/modules/storageAzureFiles/deploy.bicep
@@ -98,6 +98,9 @@ param securityPrincipalName string
 @sys.description('storage account FDQN.')
 param storageAccountFqdn string
 
+@sys.description('Storage account private endpoint static ip')
+param storageFilePrivateEndpointStaticIp string
+
 // =========== //
 // Variable declaration //
 // =========== //
@@ -179,6 +182,14 @@ module storageAndFile '../../../../carml/1.3.0/Microsoft.Storage/storageAccounts
                         vnetPrivateDnsZoneFilesId
                     ]
                 }
+                ipConfigurations: !empty(storageFilePrivateEndpointStaticIp) ? [
+                    {
+                        name: 'privateEndpointIpConfig'
+                        properties: {
+                            privateIPAddress: storageFilePrivateEndpointStaticIp
+                        }
+                    }
+                ] : []
             }
         ] : []
         tags: tags

--- a/workload/bicep/parameters/deploy-baseline-parameters-arpah.json
+++ b/workload/bicep/parameters/deploy-baseline-parameters-arpah.json
@@ -214,6 +214,9 @@
         },
         "deployGpuPolicies": {
             "value": false
+        },
+        "storageFilePrivateEndpointStaticIp": {
+            "value": "10.178.8.136"
         }
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Adds support to provide a static ip for the azure file share private endpoint.   the storageFilePrivateEndpointStaticIp parameter was added



## As part of this Pull Request I have

- [ ] Read the [Contribution Guide](https://github.com/Azure/avdaccelerator/blob/main/CONTRIBUTING.md) and ensured this PR is compliant with the guide
- [ ] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/avdaccelerator/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/avdaccelerator/issues)
- [ ] *(AVD LZA Team Only)* Associated it with relevant [ADO Items](https://dev.azure.com/CSUSolEng/Accelerator%20-%20AVD/_backlogs/backlog/Accelerator%20-%20AVD%20Team/Features)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/avdaccelerator/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Docs etc.)