### PR TITLE
disable powershell download progress

### DIFF
--- a/workload/scripts/Set-SessionHostConfiguration.ps1
+++ b/workload/scripts/Set-SessionHostConfiguration.ps1
@@ -98,6 +98,7 @@ function Install-Font {
     }    
 
 $ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
 
 try {
 


### PR DESCRIPTION
The download progress in PS is updated per-byte.

Disabling this will greatly speed up downloads.